### PR TITLE
Add CallResult Handling After Call Completion

### DIFF
--- a/PlasmaSwift/PlasmaClient.swift
+++ b/PlasmaSwift/PlasmaClient.swift
@@ -116,7 +116,11 @@ private extension PlasmaClient.Connection {
 
         init?(service: PlasmaStreamServiceServiceClient, events: [PlasmaEventType], eventHandler: @escaping (PlasmaClient.Event) -> Void) {
             do {
-                self.protoCall = try service.events(completion: nil)
+                self.protoCall = try service.events { callResult in
+                    if callResult.statusCode == .unavailable {
+                        eventHandler(.error(RPCError.callError(callResult)))
+                    }
+                }
                 self.eventHandler = eventHandler
                 subscribe(events: events)
 


### PR DESCRIPTION
After service finish, the completion handler will be called.
When it finish with status `unavailable`, the argument of the handler, CallResult, is passed with unavailable status in `statusCode property`.

The status is used to reconnection.
I add it.

Thanks.