### PR TITLE
Watch network reachability for reconnect after getting reachable

### DIFF
--- a/PlasmaSwift.podspec
+++ b/PlasmaSwift.podspec
@@ -9,4 +9,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.source_files = 'PlasmaSwift/**/*.{h,swift}'
   s.dependency 'SwiftGRPC', '~> 0.4.3'
+  s.framework = 'SystemConfiguration'
 end

--- a/PlasmaSwift/PlasmaClient.swift
+++ b/PlasmaSwift/PlasmaClient.swift
@@ -49,7 +49,7 @@ public final class PlasmaClient {
 
 public extension PlasmaClient {
     public final class Connection {
-        private var makeService: () -> PlasmaStreamServiceServiceClient
+        private let makeService: () -> PlasmaStreamServiceServiceClient
         private let eventHandler: (Event) -> Void
         private let reconnectQueue = DispatchQueue(label: "io.github.openfresh.plasma.reconnectQueue")
         private let lock = NSLock()

--- a/PlasmaSwift/PlasmaClient.swift
+++ b/PlasmaSwift/PlasmaClient.swift
@@ -1,5 +1,6 @@
 import SwiftGRPC
 import SwiftProtobuf
+import SystemConfiguration
 
 public final class PlasmaClient {
     public struct Payload {
@@ -11,23 +12,33 @@ public final class PlasmaClient {
         case next(payload: Payload)
         case error(Error)
     }
-    
+
     public static var isDebugLogEnabled = false
 
-    private let service: PlasmaStreamServiceServiceClient
-    
-    public init(host: String, port: Int, secure: Bool = true, timeout: TimeInterval = .greatestFiniteMagnitude) {
-        service = .init(address: "\(host):\(port)", secure: secure)
-        service.timeout = timeout
+    private let makeService: () -> PlasmaStreamServiceServiceClient
+
+    public convenience init(host: String, port: Int, secure: Bool = true, timeout: TimeInterval = .greatestFiniteMagnitude) {
+        self.init {
+            let service = PlasmaStreamServiceServiceClient(address: "\(host):\(port)", secure: secure)
+            service.timeout = timeout
+            return service
+        }
     }
 
-    public init(host: String, port: Int, certificates: String, timeout: TimeInterval = .greatestFiniteMagnitude) {
-        service = .init(address: "\(host):\(port)", certificates: certificates)
-        service.timeout = timeout
+    public convenience init(host: String, port: Int, certificates: String, timeout: TimeInterval = .greatestFiniteMagnitude) {
+        self.init {
+            let service = PlasmaStreamServiceServiceClient(address: "\(host):\(port)", certificates: certificates)
+            service.timeout = timeout
+            return service
+        }
     }
-    
+
+    private init(makeService: @escaping () -> PlasmaStreamServiceServiceClient) {
+        self.makeService = makeService
+    }
+
     public func connect(retryCount: Int, eventHandler: @escaping (Event) -> Void) -> Connection {
-        return .init(service: service, retryCount: retryCount, eventHandler: eventHandler)
+        return .init(retryCount: retryCount, makeService: makeService, eventHandler: eventHandler)
     }
 
     @discardableResult
@@ -38,27 +49,41 @@ public final class PlasmaClient {
 
 public extension PlasmaClient {
     public final class Connection {
-        private let service: PlasmaStreamServiceServiceClient
+        private var makeService: () -> PlasmaStreamServiceServiceClient
         private let eventHandler: (Event) -> Void
-
         private let reconnectQueue = DispatchQueue(label: "io.github.openfresh.plasma.reconnectQueue")
-        private let callLock = NSLock()
-        private var events: [PlasmaEventType] = []
+        private let lock = NSLock()
+        private var retryCount: Int
+        private var events = [PlasmaEventType]()
+        private lazy var networkReachability = NetworkReachability(queue: reconnectQueue)
+
         private var call: Call? = nil {
             didSet { oldValue?.cancel() }
         }
-        
-        fileprivate init(service: PlasmaStreamServiceServiceClient, retryCount: Int, eventHandler: @escaping (Event) -> Void) {
-            self.service = service
+
+        fileprivate init(retryCount: Int, makeService: @escaping () -> PlasmaStreamServiceServiceClient, eventHandler: @escaping (Event) -> Void) {
+            self.retryCount = retryCount
+            self.makeService = makeService
             self.eventHandler = eventHandler
 
-            connect(retryCount: retryCount)
+            connect()
+            networkReachability?.changed = { [weak self] networkReachability in
+                guard let `self` = self else { return }
+
+                if networkReachability.isReachable {
+                    PlasmaClient.log("network reachability changed. trying to reconnect...")
+                    self.connect()
+
+                } else {
+                    self.shutdown()
+                }
+            }
         }
-        
+
         @discardableResult
         public func subscribe(eventTypes: [String]) -> Self {
-            callLock.lock()
-            defer { callLock.unlock() }
+            lock.lock()
+            defer { lock.unlock() }
 
             let events = eventTypes.map(PlasmaEventType.init)
             call?.subscribe(events: events)
@@ -67,56 +92,76 @@ public extension PlasmaClient {
             PlasmaClient.log("subscribed events sent to plasma: \(eventTypes)")
             return self
         }
-        
-        public func shutdown() {
-            callLock.lock()
-            defer { callLock.unlock() }
 
-            call?.cancel()
+        public func shutdown() {
+            lock.lock()
+            defer { lock.unlock() }
+
+            call = nil
 
             PlasmaClient.log("connection closed")
         }
-        
-        private func connect(retryCount: Int) {
-            callLock.lock()
-            defer { callLock.unlock() }
 
+        private func connect() {
+            lock.lock()
+            defer { lock.unlock() }
+
+            let service = makeService()
             call = Call(service: service, events: events) { [weak self] event in
+                guard let `self` = self else { return }
+
+                let isMaybeReachable = self.networkReachability?.isReachable ?? false
+
                 switch event {
                 case .next(let payload):
                     PlasmaClient.log("received payload: \(payload)")
+                    self.eventHandler(event)
 
-                case .error(let error as RPCError) where error.callResult?.statusCode == .unavailable && retryCount > 0:
-                    PlasmaClient.log("stream service is gone. \(error.localizedDescription)")
-                    self?.reconnect(after: 5, remainingCount: retryCount - 1)
-                    return
+                case .error(let error) where !isMaybeReachable:
+                    PlasmaClient.log("stream is not reachable. error: \(error.localizedDescription)")
 
                 case .error(let error):
-                    PlasmaClient.log("error: \(error.localizedDescription)")
-                }
+                    PlasmaClient.log("received error: \(error.localizedDescription).")
+                    let reconnectResult = self.reconnect(after: 5)
 
-                self?.eventHandler(event)
+                    if !reconnectResult {
+                        self.eventHandler(event)
+                    }
+                }
             }
         }
 
-        private func reconnect(after interval: TimeInterval, remainingCount: Int) {
+        private func reconnect(after interval: TimeInterval) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+
+            let events = self.events
+            let remaining = retryCount - 1
+            self.retryCount = remaining
+
+            guard remaining >= 0 else { return false }
+
             reconnectQueue.asyncAfter(deadline: .now() + interval) { [weak self] in
                 guard let `self` = self else { return }
 
-                PlasmaClient.log("trying to reconnect... remaining: \(remainingCount) times, eventTypes: \(self.events.map { $0.type })")
-                self.connect(retryCount: remainingCount)
+                PlasmaClient.log("trying to reconnect... remaining: \(remaining) times, eventTypes: \(events.map { $0.type })")
+                self.connect()
             }
+
+            return true
         }
     }
 }
 
 private extension PlasmaClient.Connection {
     final class Call {
+        private let service: PlasmaStreamServiceServiceClient
         private let eventHandler: (PlasmaClient.Event) -> Void
         private let protoCall: PlasmaStreamServiceEventsCall
 
         init?(service: PlasmaStreamServiceServiceClient, events: [PlasmaEventType], eventHandler: @escaping (PlasmaClient.Event) -> Void) {
             do {
+                self.service = service
                 self.eventHandler = eventHandler
                 self.protoCall = try service.events { callResult in
                     if callResult.statusCode == .unavailable {
@@ -141,15 +186,14 @@ private extension PlasmaClient.Connection {
                     case .result(let payload?) where payload.hasEventType:
                         let payload = PlasmaClient.Payload(data: payload.data, eventType: payload.eventType.type)
                         self.eventHandler(.next(payload: payload))
+                        self.subscribeReceiveMessage()
 
                     case .result:
-                        return
+                        break
 
                     case .error(let error):
                         self.eventHandler(.error(error))
                     }
-
-                    self.subscribeReceiveMessage()
                 }
 
             } catch {
@@ -162,7 +206,11 @@ private extension PlasmaClient.Connection {
 
             do {
                 let request = PlasmaRequest(events: events)
-                try protoCall.send(request)
+                try protoCall.send(request) { [weak self] error in
+                    guard let `self` = self, let error = error else { return }
+
+                    self.eventHandler(.error(error))
+                }
 
             } catch {
                 eventHandler(.error(error))
@@ -174,7 +222,12 @@ private extension PlasmaClient.Connection {
         func cancel() {
             do {
                 let request = PlasmaRequest(forceClose: true)
-                try protoCall.send(request)
+                try protoCall.send(request) { [weak self] error in
+                    guard let `self` = self, let error = error else { return }
+
+                    self.eventHandler(.error(error))
+                }
+
                 protoCall.cancel()
 
             } catch {
@@ -184,21 +237,82 @@ private extension PlasmaClient.Connection {
     }
 }
 
+private final class NetworkReachability {
+    var changed: ((NetworkReachability) -> Void)?
+
+    var isReachable: Bool {
+        return currentFlags.contains(.reachable)
+    }
+
+    private let reachability: SCNetworkReachability
+    private var currentFlags: SCNetworkReachabilityFlags
+
+    init?(queue: DispatchQueue) {
+        var address = sockaddr()
+        address.sa_len = UInt8(MemoryLayout<sockaddr>.size)
+        address.sa_family = sa_family_t(AF_INET)
+
+        guard let reachability = SCNetworkReachabilityCreateWithAddress(nil, &address) else {
+            return nil
+        }
+
+        var _flags = SCNetworkReachabilityFlags()
+        let getFlagsResult = SCNetworkReachabilityGetFlags(reachability, &_flags)
+
+        self.reachability = reachability
+        self.currentFlags = getFlagsResult ? _flags : .init()
+
+        var context = SCNetworkReachabilityContext(
+            version: 0,
+            info: .init(Unmanaged<NetworkReachability>.passUnretained(self).toOpaque()),
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+
+        let setCallbackResult = SCNetworkReachabilitySetCallback(reachability, reachabilityCallback, &context)
+        let setDispatchQueueResult = SCNetworkReachabilitySetDispatchQueue(reachability, queue)
+
+        guard setCallbackResult && setDispatchQueueResult else {
+            return nil
+        }
+    }
+
+    func reachabilityChanged(with flags: SCNetworkReachabilityFlags) {
+        guard currentFlags != flags else { return }
+
+        currentFlags = flags
+        changed?(self)
+    }
+
+    deinit {
+        SCNetworkReachabilitySetCallback(reachability, nil, nil)
+        SCNetworkReachabilitySetDispatchQueue(reachability, nil)
+    }
+}
+
+private func reachabilityCallback(reachability: SCNetworkReachability, flags: SCNetworkReachabilityFlags, info: UnsafeMutableRawPointer?) {
+    guard let info = info else { return }
+
+    let networkReachability = Unmanaged<NetworkReachability>.fromOpaque(info).takeUnretainedValue()
+    networkReachability.reachabilityChanged(with: flags)
+}
+
 private extension PlasmaClient {
     static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateStyle = .long
-        formatter.timeStyle = .long
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSZ"
         return formatter
     }()
-    
+
     static func log<T>(_ data: @autoclosure () -> T) {
         guard isDebugLogEnabled else { return }
 
         let now = Date()
         let dateString = dateFormatter.string(from: now)
         let log = "\(dateString) [Plasma] \(data())"
-        
+
         print(log)
     }
 }
@@ -208,7 +322,7 @@ private extension PlasmaRequest {
         self.init()
         self.forceClose = forceClose
     }
-    
+
     init(events: [PlasmaEventType]) {
         self.init()
         self.events = events


### PR DESCRIPTION
## Changes
- Watch network reachability to reconnect or shutdown
- Recreate a service client with a channel when reconnecting
- Not try to reconnect when network not reachable
- Always attempt to reconnect when network reachable and an error occurs
- Continuous receiving will be interrupted if an error occurs
- Sending request is now asynchronous
- Fix exclusive access control
- Change the logging format